### PR TITLE
[FE] 이음 초기 타이틀 화면 구현

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,56 @@
 import 'package:flutter/material.dart';
+import '../widgets/user/button.dart';
+import '../widgets/user/skill_list.dart';
+import '../screens/user/home.dart';
+import '../widgets/user/navigation.dart';
+import '../screens/common/title.dart';
+import 'routes.dart';
 
-void main() {
-  runApp(const MyApp());
-}
+// 위젯 파일들은 따로 dart 파일에 두고 import해도 됩니다. 지금은 예시.
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+void main() => runApp(const PreviewApp(child: TitleScreen()));
 
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
+// 보고 싶은 위젯은 아래처럼 child에 직접 전달!
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+// 전체 앱이 아니라, SINGLE 위젯만 centering/배경 등이 적용된 프리뷰 앱!
+class PreviewApp extends StatelessWidget {
+  final Widget child;
+  const PreviewApp({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+    return MaterialApp(initialRoute: '/', routes: appRoutes, debugShowCheckedModeBanner: false);
+  }
+}
+
+// ====== 아래부터는 커스텀 위젯들! ======
+
+class NavigationBarPreview extends StatefulWidget {
+  const NavigationBarPreview({super.key});
+
+  @override
+  State<NavigationBarPreview> createState() => _NavigationBarPreviewState();
+}
+
+class _NavigationBarPreviewState extends State<NavigationBarPreview> {
+  int _currentIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // 선택된 탭 인덱스 표시 (테스트용)
+        const SizedBox(height: 24),
+        CustomNavigationBar(
+          currentIndex: _currentIndex,
+          onTap: (index) {
+            setState(() {
+              _currentIndex = index;
+            });
+          },
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      ],
     );
   }
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'screens/common/title.dart';
+import 'screens/user/home.dart';
+
+final Map<String, WidgetBuilder> appRoutes = {
+  '/': (context) => const TitleScreen(),
+  '/home': (context) => const HomeScreen(),
+};

--- a/lib/screens/common/title.dart
+++ b/lib/screens/common/title.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import '../../../widgets/user/button.dart';
+
+class TitleScreen extends StatelessWidget {
+  const TitleScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF000000),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Center(
+            // ← 이 부분 추가!
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                const Spacer(flex: 2),
+                // 이미지 2개를 세로로 중앙에 배치
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Container(
+                      width: 290,
+                      height: 155,
+                      // decoration: BoxDecoration(
+                      //   borderRadius: BorderRadius.circular(28),
+                      //   border: Border.all(color: Color(0xFFE0E0E0)),
+                      // ),
+                      child: Center(child: Image.asset('assets/logos/eum_logo_title.png', fit: BoxFit.contain)),
+                    ),
+                    Container(
+                      width: 140,
+                      height: 100,
+                      // decoration: BoxDecoration(
+                      //   borderRadius: BorderRadius.circular(20),
+                      //   border: Border.all(color: Color(0xFFE0E0E0)),
+                      // ),
+                      child: Center(child: Image.asset('assets/logos/eum_word_title.png', fit: BoxFit.contain)),
+                    ),
+                  ],
+                ),
+                const Spacer(flex: 3),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 40),
+                  child: Button(
+                    text: '시작하기',
+                    width: 350,
+                    height: 48,
+                    color: Color(0xffDAD3E8),
+                    onPressed: () {
+                      Navigator.pushReplacementNamed(context, '/home');
+                    },
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 20),
+                  child: Column(
+                    children: [
+                      GestureDetector(
+                        onTap: () {
+                          // TODO: 이동 로직 구현
+                        },
+                        child: const Text(
+                          '장인·작가이신가요?',
+                          style: TextStyle(color: Color(0xFF868383), fontSize: 15, fontWeight: FontWeight.w500),
+                        ),
+                      ),
+                      Container(width: 120, height: 2, color: Color(0xFF868383)),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/user/home.dart
+++ b/lib/screens/user/home.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF1F1F1),
+      body: SafeArea(
+        child: Column(
+          children: [
+            // 헤더
+            Container(
+              height: 130,
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Container(
+                  width: 98,
+                  height: 52,
+                  color: Colors.grey[300], // 이미지 자리
+                  child: const Center(child: Text('로고')),
+                ),
+              ),
+            ),
+            // 인기 강의 (오늘의 인기 강의)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 0),
+              child: Container(
+                margin: const EdgeInsets.only(bottom: 8),
+                decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(30)),
+                width: double.infinity,
+                height: 188,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text('오늘의 인기 강의', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                          Icon(Icons.arrow_forward, size: 28, color: Colors.grey[700]),
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      height: 140,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        itemCount: 3,
+                        separatorBuilder: (_, __) => const SizedBox(width: 8),
+                        itemBuilder: (context, index) {
+                          return PopularClassCard();
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // 인기 강의 (위치 기반 추천)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 0),
+              child: Container(
+                margin: const EdgeInsets.only(bottom: 8),
+                decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(30)),
+                width: double.infinity,
+                height: 188,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          const Text('사용자 위치 기반 추천 강의', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                          Icon(Icons.arrow_forward, size: 28, color: Colors.grey[700]),
+                        ],
+                      ),
+                    ),
+                    SizedBox(
+                      height: 140,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        itemCount: 3,
+                        separatorBuilder: (_, __) => const SizedBox(width: 8),
+                        itemBuilder: (context, index) {
+                          return PopularClassCard();
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // 정부지원금 배너
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 0),
+              child: Container(
+                margin: const EdgeInsets.only(bottom: 8),
+                width: double.infinity,
+                height: 108,
+                child: Row(
+                  children: [
+                    const SizedBox(width: 16),
+                    Container(
+                      width: 72,
+                      height: 72,
+                      decoration: BoxDecoration(color: Colors.grey[400], borderRadius: BorderRadius.circular(36)),
+                      child: const Center(child: Text('임티')),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Text(
+                            '이음 제안',
+                            style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold, color: Colors.black54),
+                          ),
+                          const SizedBox(height: 4),
+                          const Text('나에게 꼭 맞는 정부 지원 혜택', style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+                          const SizedBox(height: 8),
+                          Row(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                                decoration: BoxDecoration(
+                                  color: Colors.grey[700]?.withOpacity(0.5),
+                                  borderRadius: BorderRadius.circular(50),
+                                ),
+                                child: const Text(
+                                  '클릭 한 번으로 확인하기',
+                                  style: TextStyle(fontSize: 9, color: Colors.white, fontWeight: FontWeight.bold),
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Icon(Icons.arrow_forward, size: 20, color: Colors.grey[700]),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                  ],
+                ),
+              ),
+            ),
+            // 목록들 배너
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 0),
+              child: Column(
+                children: [
+                  BannerButton(icon: Icons.people, text: '장인 • 작가 목록 보기'),
+                  BannerButton(icon: Icons.list, text: '전통 기술 목록 보기'),
+                ],
+              ),
+            ),
+            const Spacer(),
+            // 네비게이션 바
+            Container(
+              height: 80,
+              width: double.infinity,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+                boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.05), blurRadius: 10)],
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: const [
+                  Icon(Icons.home, size: 32),
+                  Icon(Icons.map, size: 32),
+                  Icon(Icons.person, size: 32),
+                  Icon(Icons.explore, size: 32),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class PopularClassCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 120,
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      decoration: BoxDecoration(color: Colors.grey[200], borderRadius: BorderRadius.circular(30)),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            height: 80,
+            width: double.infinity,
+            decoration: BoxDecoration(color: Colors.grey[400], borderRadius: BorderRadius.circular(30)),
+            child: const Center(
+              child: Text('Photo', style: TextStyle(fontSize: 15, fontWeight: FontWeight.bold)),
+            ),
+          ),
+          const SizedBox(height: 4),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            child: Text('원데이 클래스 상세 설명입니다.', style: TextStyle(fontSize: 8, fontWeight: FontWeight.bold)),
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 8),
+            //child: Text('52,000원', style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class BannerButton extends StatelessWidget {
+  final IconData icon;
+  final String text;
+  const BannerButton({required this.icon, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.03), blurRadius: 4)],
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 28, color: Colors.black54),
+          const SizedBox(width: 16),
+          Text(text, style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+          const Spacer(),
+          const Icon(Icons.arrow_forward_ios, size: 18, color: Colors.black26),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 📌 PR 제목
[Feature] 이음 타이틀 화면 구현

---

### ✅ 작업 개요
- 타이틀 로고 배치
- 버튼 위젯 배치
- 텍스트 UI 구현
- 홈 화면으로의 라우팅 구현
- 관련 이슈 번호: Closes #2 

---

### 🎨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| 기능 추가 | 타이틀 화면 스크린 구현 |
| 스타일링 | 타이틀 화면에 필요한 기본적인 UI 구현 |
| 라우팅 | routes.dart에 타이틀 화면과 홈 화면 라우팅 추가 |

---

### 📷 스크린샷 (변경 UI가 있다면 첨부)

<img width="645" height="1435" alt="image" src="https://github.com/user-attachments/assets/1d5ea056-eb85-4188-b8c2-82970fee3b45" />


---

### 📂 관련 파일 경로
- 'eum/lib/main.dart'
- 'eum/lib/screens/common/title.dart'
- 'eum/lib/screens/user/title.dart'
- 'eum/lib/widgets/user/button.dart'
- 'eum/lib/routes.dart

---

### 🧪 테스트 및 검증
- [ ] 기능 직접 테스트 완료  
- [ ] 반응형 확인  
- [ ] 오류 없음 확인

---

### 🙋 리뷰 포인트
- UI 구조 리뷰 필요, FE 개발자 한정 코드 리팩토링 여부 피드백 필요

---

### 📎 참고 자료

---

### 📌 기타 공유사항
- 장인/작가로의 라우팅은 미완성. 추후 구현 예정
- 테스트 용도의 홈 화면 구현. 추후 리팩토링 에정이기에 지금 단계에서는 넘어가도 무방
- main.dart에 위젯 테스트를 위한 여러 잡다한 코드들이 포함. 이들 또한 추후 삭제할 예정.

