### PR TITLE
[FE] 전통 기술 / 장인 작가 목록 구현

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:eum_demo/screens/common/title.dart';
 import 'package:flutter/material.dart';
-
 import 'routes.dart';
 
 // 위젯 파일들은 따로 dart 파일에 두고 import해도 됩니다. 지금은 예시.
@@ -16,11 +15,7 @@ class PreviewApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      initialRoute: '/',
-      routes: appRoutes,
-      debugShowCheckedModeBanner: false,
-    );
+    return MaterialApp(initialRoute: '/', routes: appRoutes, debugShowCheckedModeBanner: false);
   }
 }
 

--- a/lib/screens/user/creator_list_screen.dart
+++ b/lib/screens/user/creator_list_screen.dart
@@ -6,8 +6,66 @@ class CreatorListScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('장인 목록')),
-      body: Center(child: Text('장인 목록 페이지')),
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        surfaceTintColor: Colors.transparent,
+        backgroundColor: const Color.fromARGB(255, 255, 255, 255),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, color: Colors.black),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: const Text(
+          '장인 목록',
+          style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold, fontSize: 20, letterSpacing: -1.2),
+        ),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search, color: Colors.black, size: 32),
+            onPressed: () {
+              showDialog(
+                context: context,
+                barrierColor: Colors.black.withOpacity(0.2),
+                builder: (context) {
+                  return Align(
+                    alignment: Alignment.topCenter,
+                    child: Material(
+                      color: Colors.transparent,
+                      child: Container(
+                        margin: const EdgeInsets.only(top: 60, left: 20, right: 20),
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(16),
+                          boxShadow: [BoxShadow(color: Colors.black26, blurRadius: 8)],
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.search, color: Colors.black54),
+                            const SizedBox(width: 8),
+                            const Expanded(
+                              child: TextField(
+                                autofocus: true,
+                                decoration: InputDecoration(hintText: '검색어를 입력하세요', border: InputBorder.none),
+                              ),
+                            ),
+                            IconButton(icon: const Icon(Icons.close), onPressed: () => Navigator.of(context).pop()),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(1.0),
+          child: Container(color: Colors.grey[500], height: 1.0),
+        ),
+      ),
+      body: const Center(child: Text('장인 목록 페이지')),
     );
   }
 }

--- a/lib/screens/user/creator_list_screen.dart
+++ b/lib/screens/user/creator_list_screen.dart
@@ -6,10 +6,10 @@ class CreatorListScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: const Color(0xFFF1F1F1),
       appBar: AppBar(
         surfaceTintColor: Colors.transparent,
-        backgroundColor: const Color.fromARGB(255, 255, 255, 255),
+        backgroundColor: const Color(0xFFF1F1F1),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new, color: Colors.black),
           onPressed: () => Navigator.of(context).pop(),

--- a/lib/screens/user/creator_list_screen.dart
+++ b/lib/screens/user/creator_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../widgets/user/creator_list.dart';
 
 class CreatorListScreen extends StatelessWidget {
   const CreatorListScreen({super.key});
@@ -65,7 +66,26 @@ class CreatorListScreen extends StatelessWidget {
           child: Container(color: Colors.grey[500], height: 1.0),
         ),
       ),
-      body: const Center(child: Text('장인 목록 페이지')),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+        children: [
+          CreatorList(title: '무형문화재 000', photoLabel: 'Photo'),
+          CreatorList(title: '무형문화재 000', photoLabel: 'Photo'),
+          CreatorList(title: '작가 000', photoLabel: 'Photo'),
+          CreatorList(title: '무형유산 000', photoLabel: 'Photo'),
+          CreatorList(title: '무형유산 000', photoLabel: 'Photo'),
+          CreatorList(title: '전수 교육자 000', photoLabel: 'Photo'),
+          CreatorList(title: '작가 000', photoLabel: 'Photo'),
+          // 7개 반복 × 3세트
+          CreatorList(title: '무형문화재 000', photoLabel: 'Photo'),
+          CreatorList(title: '무형문화재 000', photoLabel: 'Photo'),
+          CreatorList(title: '작가 000', photoLabel: 'Photo'),
+          CreatorList(title: '무형유산 000', photoLabel: 'Photo'),
+          CreatorList(title: '무형유산 000', photoLabel: 'Photo'),
+          CreatorList(title: '전수 교육자 000', photoLabel: 'Photo'),
+          CreatorList(title: '작가 000', photoLabel: 'Photo'),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/user/skill_list_screen.dart
+++ b/lib/screens/user/skill_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../../widgets/user/skill_list.dart';
 
 class SkillListScreen extends StatelessWidget {
   const SkillListScreen({super.key});
@@ -6,10 +7,10 @@ class SkillListScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: const Color(0xFFF1F1F1),
       appBar: AppBar(
         surfaceTintColor: Colors.transparent,
-        backgroundColor: const Color.fromARGB(255, 255, 255, 255),
+        backgroundColor: const Color(0xFFF1F1F1),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new, color: Colors.black),
           onPressed: () => Navigator.of(context).pop(),
@@ -65,7 +66,20 @@ class SkillListScreen extends StatelessWidget {
           child: Container(color: Colors.grey[500], height: 1.0),
         ),
       ),
-      body: const Center(child: Text('전통 기술 목록 페이지')),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+        children: [
+          for (int i = 0; i < 3; i++) ...[
+            SkillList(title: '금속 공예', photoLabel: 'Photo'),
+            SkillList(title: '나전칠기', photoLabel: 'Photo'),
+            SkillList(title: '도자기', photoLabel: 'Photo'),
+            SkillList(title: '칠장 (옻칠)', photoLabel: 'Photo'),
+            SkillList(title: '칠장 (칠화)', photoLabel: 'Photo'),
+            SkillList(title: '칠장 (황칠)', photoLabel: 'Photo'),
+            SkillList(title: '칠장 (남태칠)', photoLabel: 'Photo'),
+          ],
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/user/skill_list_screen.dart
+++ b/lib/screens/user/skill_list_screen.dart
@@ -6,8 +6,66 @@ class SkillListScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('전통 기술 목록')),
-      body: Center(child: Text('전통 기술 목록 페이지')),
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        surfaceTintColor: Colors.transparent,
+        backgroundColor: const Color.fromARGB(255, 255, 255, 255),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, color: Colors.black),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: const Text(
+          '전통 기술 목록',
+          style: TextStyle(color: Colors.black, fontWeight: FontWeight.bold, fontSize: 20, letterSpacing: -1.2),
+        ),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search, color: Colors.black, size: 32),
+            onPressed: () {
+              showDialog(
+                context: context,
+                barrierColor: Colors.black.withOpacity(0.2),
+                builder: (context) {
+                  return Align(
+                    alignment: Alignment.topCenter,
+                    child: Material(
+                      color: Colors.transparent,
+                      child: Container(
+                        margin: const EdgeInsets.only(top: 60, left: 20, right: 20),
+                        padding: const EdgeInsets.all(16),
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(16),
+                          boxShadow: [BoxShadow(color: Colors.black26, blurRadius: 8)],
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.search, color: Colors.black54),
+                            const SizedBox(width: 8),
+                            const Expanded(
+                              child: TextField(
+                                autofocus: true,
+                                decoration: InputDecoration(hintText: '검색어를 입력하세요', border: InputBorder.none),
+                              ),
+                            ),
+                            IconButton(icon: const Icon(Icons.close), onPressed: () => Navigator.of(context).pop()),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(1.0),
+          child: Container(color: Colors.grey[500], height: 1.0),
+        ),
+      ),
+      body: const Center(child: Text('전통 기술 목록 페이지')),
     );
   }
 }

--- a/lib/widgets/user/creator_detail.dart
+++ b/lib/widgets/user/creator_detail.dart
@@ -1,0 +1,125 @@
+import 'button.dart';
+import 'package:flutter/material.dart';
+
+class CreatorDetail extends StatelessWidget {
+  final String name;
+  final String skill;
+  final String works;
+  final String bio;
+  final Widget? image;
+  final VoidCallback? onMatch;
+
+  const CreatorDetail({
+    super.key,
+    required this.name,
+    required this.skill,
+    required this.works,
+    required this.bio,
+    this.image,
+    this.onMatch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final double cardWidth = size.width * 0.92;
+    final double cardHeight = size.height * 0.85;
+    return Center(
+      child: SingleChildScrollView(
+        child: Container(
+          width: cardWidth,
+          height: cardHeight,
+          decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(30)),
+          child: Stack(
+            children: [
+              // 닫기(X) 아이콘
+              Positioned(
+                right: 10,
+                top: 10,
+                child: GestureDetector(
+                  onTap: () => Navigator.of(context).pop(),
+                  child: Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(color: Colors.white, shape: BoxShape.circle),
+                    child: const Icon(Icons.close, size: 30, color: Colors.black),
+                  ),
+                ),
+              ),
+              // 이미지 영역
+              Positioned(
+                left: cardWidth * 0.1,
+                top: cardHeight * 0.045,
+                child: Container(
+                  width: cardWidth * 0.8,
+                  height: cardHeight * 0.29,
+                  decoration: BoxDecoration(color: const Color(0xFFD9D9D9), borderRadius: BorderRadius.circular(18)),
+                  child:
+                      image ??
+                      Center(
+                        child: Text(
+                          'Photo',
+                          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18, color: Colors.black),
+                        ),
+                      ),
+                ),
+              ),
+              // 이름
+              Positioned(
+                left: cardWidth * 0.15,
+                top: cardHeight * 0.36,
+                child: SizedBox(
+                  width: cardWidth * 0.7,
+                  height: cardHeight * 0.09,
+                  child: Center(
+                    child: Text(
+                      name,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.black,
+                        fontSize: 32,
+                        fontWeight: FontWeight.w700,
+                        height: 0.9,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              // 상세 정보
+              Positioned(
+                left: cardWidth * 0.13,
+                top: cardHeight * 0.52,
+                child: SizedBox(
+                  width: cardWidth * 0.77,
+                  height: cardHeight * 0.23,
+                  child: Text(
+                    '기술 : $skill\n\n주요작품 : $works\n\n약력 : $bio',
+                    style: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      height: 1.38,
+                    ),
+                  ),
+                ),
+              ),
+              // 매칭 신청 버튼
+              Positioned(
+                left: cardWidth * 0.18,
+                top: cardHeight * 0.86,
+                child: Button(
+                  text: '매칭 신청하기',
+                  onPressed: onMatch,
+                  width: cardWidth * 0.65,
+                  height: 48,
+                  backgroundColor: const Color(0xFFDAD3E8),
+                  textColor: Colors.black,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/user/creator_detail.dart
+++ b/lib/widgets/user/creator_detail.dart
@@ -1,4 +1,5 @@
 import 'button.dart';
+import 'request_note.dart';
 import 'package:flutter/material.dart';
 
 class CreatorDetail extends StatelessWidget {
@@ -109,7 +110,16 @@ class CreatorDetail extends StatelessWidget {
                 top: cardHeight * 0.86,
                 child: Button(
                   text: '매칭 신청하기',
-                  onPressed: onMatch,
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder: (_) => Dialog(
+                        backgroundColor: Colors.transparent,
+                        insetPadding: EdgeInsets.zero,
+                        child: RequestNote(nickname: '닉네임'),
+                      ),
+                    );
+                  },
                   width: cardWidth * 0.65,
                   height: 48,
                   backgroundColor: const Color(0xFFDAD3E8),

--- a/lib/widgets/user/creator_list.dart
+++ b/lib/widgets/user/creator_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'creator_detail.dart';
 
 class CreatorList extends StatelessWidget {
   final String title;
@@ -10,7 +11,14 @@ class CreatorList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onTap,
+      onTap:
+          onTap ??
+          () {
+            showDialog(
+              context: context,
+              builder: (_) => CreatorDetail(name: title, skill: '기술 예시', works: '주요작품 예시', bio: '약력 예시'),
+            );
+          },
       child: Container(
         height: 80,
         width: double.infinity,

--- a/lib/widgets/user/creator_list.dart
+++ b/lib/widgets/user/creator_list.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class CreatorList extends StatelessWidget {
+  final String title;
+  final String photoLabel;
+  final VoidCallback? onTap;
+
+  const CreatorList({super.key, this.title = '이름', this.photoLabel = 'Photo', this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 80,
+        width: double.infinity,
+        margin: const EdgeInsets.symmetric(vertical: 6),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(10),
+          boxShadow: [BoxShadow(color: Colors.black.withOpacity(0.06), blurRadius: 6, offset: const Offset(0, 2))],
+        ),
+        child: Row(
+          children: [
+            // 왼쪽 회색 아이콘 영역
+            Container(
+              width: 65,
+              height: 55,
+              margin: const EdgeInsets.only(left: 17, right: 16),
+              decoration: BoxDecoration(color: const Color(0xFFD9D9D9), borderRadius: BorderRadius.circular(10)),
+              child: Center(
+                child: Text(
+                  photoLabel,
+                  style: const TextStyle(fontSize: 10, fontWeight: FontWeight.bold, color: Colors.black),
+                ),
+              ),
+            ),
+            // 가운데 텍스트 영역
+            Expanded(
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  title,
+                  style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold, color: Colors.black),
+                ),
+              ),
+            ),
+            // 오른쪽 확장 아이콘
+            Padding(
+              padding: const EdgeInsets.only(right: 16),
+              child: Icon(Icons.chevron_right, size: 24, color: Colors.black.withOpacity(0.5)),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/user/request_note.dart
+++ b/lib/widgets/user/request_note.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'button.dart';
+
+class RequestNote extends StatelessWidget {
+  final String nickname;
+  final ValueChanged<String>? onSend;
+
+  const RequestNote({super.key, this.nickname = '닉네임', this.onSend});
+
+  @override
+  Widget build(BuildContext context) {
+    final TextEditingController controller = TextEditingController();
+    final size = MediaQuery.of(context).size;
+    final double cardWidth = size.width * 0.92;
+    final double cardHeight = size.height * 0.85;
+    return Center(
+      child: Container(
+        width: cardWidth,
+        height: cardHeight,
+        decoration: BoxDecoration(
+          color: const Color(0xFFE3E3E3),
+          borderRadius: BorderRadius.circular(cardWidth * 0.085),
+        ),
+        child: Stack(
+          children: [
+            // 메세지 전송 버튼
+            Positioned(
+              left: cardWidth * 0.16,
+              top: cardHeight * 0.86,
+              child: Button(
+                text: '메세지 전송',
+                onPressed: () {
+                  if (onSend != null) onSend!(controller.text);
+                  Navigator.of(context).pop();
+                  Navigator.of(context).pop();
+                },
+                width: cardWidth * 0.68,
+                height: 48,
+                backgroundColor: Colors.white,
+                textColor: const Color(0xFF9785BA),
+                borderColor: const Color(0xFF9785BA),
+              ),
+            ),
+            // 상단 프로필 카드
+            Positioned(
+              left: cardWidth * 0.014,
+              top: cardHeight * 0.10,
+              child: Container(
+                width: cardWidth * 0.97,
+                height: cardHeight * 0.17,
+                child: Stack(
+                  children: [
+                    Positioned(
+                      left: cardWidth * 0.075,
+                      top: cardHeight * 0.012,
+                      child: Container(
+                        width: cardWidth * 0.82,
+                        height: cardHeight * 0.13,
+                        decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(cardWidth * 0.085),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      left: cardWidth * 0.135,
+                      top: cardHeight * 0.039,
+                      child: Container(
+                        width: cardWidth * 0.15,
+                        height: cardWidth * 0.15,
+                        decoration: BoxDecoration(color: const Color(0xFF747474), shape: BoxShape.circle),
+                      ),
+                    ),
+                    Positioned(
+                      left: cardWidth * 0.315,
+                      top: cardHeight * 0.045,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(
+                            width: cardWidth * 0.41,
+                            child: Text(
+                              nickname,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: Colors.black,
+                                fontSize: 20,
+                                fontWeight: FontWeight.w700,
+                                height: 1.10,
+                              ),
+                            ),
+                          ),
+                          SizedBox(height: cardHeight * 0.018),
+                          SizedBox(width: cardWidth * 0.50, child: _RequestNoteCheckRow()),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // 메세지 입력 영역
+            Positioned(
+              left: cardWidth * 0.09,
+              top: cardHeight * 0.28,
+              child: Container(
+                width: cardWidth * 0.82,
+                height: cardHeight * 0.55,
+                decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(cardWidth * 0.085)),
+                child: Padding(
+                  padding: EdgeInsets.all(cardWidth * 0.05),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(height: cardHeight * 0.02),
+                      const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              '장인•작가님께 전달하고 싶은 메시지를\n입력해주세요. (300자 이내)',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                color: Colors.black54,
+                                fontSize: 12,
+                                fontWeight: FontWeight.w700,
+                                height: 2.20,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      SizedBox(height: cardHeight * 0.03),
+                      Expanded(
+                        child: SingleChildScrollView(
+                          child: TextField(
+                            controller: controller,
+                            maxLength: 300,
+                            maxLines: 10,
+                            decoration: InputDecoration(
+                              hintText: '메시지를 입력하세요',
+                              border: OutlineInputBorder(borderRadius: BorderRadius.circular(cardWidth * 0.045)),
+                              contentPadding: EdgeInsets.symmetric(
+                                horizontal: cardWidth * 0.03,
+                                vertical: cardHeight * 0.01,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            // 닫기(X) 아이콘
+            Positioned(
+              right: 10,
+              top: 10,
+              child: GestureDetector(
+                onTap: () {
+                  Navigator.of(context).pop();
+                  Navigator.of(context).pop();
+                },
+                child: SizedBox(
+                  width: cardWidth * 0.09,
+                  height: cardWidth * 0.09,
+                  child: const Icon(Icons.close, size: 30, color: Colors.black),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RequestNoteCheckRow extends StatefulWidget {
+  const _RequestNoteCheckRow({Key? key}) : super(key: key);
+  @override
+  State<_RequestNoteCheckRow> createState() => _RequestNoteCheckRowState();
+}
+
+class _RequestNoteCheckRowState extends State<_RequestNoteCheckRow> {
+  bool checked = false;
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        SizedBox(
+          width: 18,
+          height: 18,
+          child: Checkbox(
+            value: checked,
+            onChanged: (val) {
+              setState(() {
+                checked = val ?? false;
+              });
+            },
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            visualDensity: VisualDensity(horizontal: -4, vertical: -4),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+          ),
+        ),
+        SizedBox(width: 5),
+        Text(
+          '장인•작가님께 내 정보 함께 보내기',
+          style: const TextStyle(color: Colors.black54, fontSize: 10, fontWeight: FontWeight.w700, height: 2.20),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/user/skill_detail.dart
+++ b/lib/widgets/user/skill_detail.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+
+class SkillDetail extends StatelessWidget {
+  final String name;
+  final String skill;
+  final String works;
+  final String bio;
+  final Widget? image;
+
+  const SkillDetail({
+    super.key,
+    required this.name,
+    required this.skill,
+    required this.works,
+    required this.bio,
+    this.image,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final double cardWidth = size.width * 0.92;
+    final double cardHeight = size.height * 0.85;
+    return Center(
+      child: SingleChildScrollView(
+        child: Container(
+          width: cardWidth,
+          height: cardHeight,
+          decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(30)),
+          child: Stack(
+            children: [
+              // 닫기(X) 아이콘
+              Positioned(
+                right: 10,
+                top: 10,
+                child: GestureDetector(
+                  onTap: () => Navigator.of(context).pop(),
+                  child: Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(color: Colors.white, shape: BoxShape.circle),
+                    child: const Icon(Icons.close, size: 30, color: Colors.black),
+                  ),
+                ),
+              ),
+              // 이미지 영역
+              Positioned(
+                left: cardWidth * 0.1,
+                top: cardHeight * 0.045,
+                child: Container(
+                  width: cardWidth * 0.8,
+                  height: cardHeight * 0.29,
+                  decoration: BoxDecoration(color: const Color(0xFFD9D9D9), borderRadius: BorderRadius.circular(18)),
+                  child:
+                      image ??
+                      Center(
+                        child: Text(
+                          'Photo',
+                          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18, color: Colors.black),
+                        ),
+                      ),
+                ),
+              ),
+              // 이름
+              Positioned(
+                left: cardWidth * 0.15,
+                top: cardHeight * 0.36,
+                child: SizedBox(
+                  width: cardWidth * 0.7,
+                  height: cardHeight * 0.09,
+                  child: Center(
+                    child: Text(
+                      name,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.black,
+                        fontSize: 32,
+                        fontWeight: FontWeight.w700,
+                        height: 0.9,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              // 상세 정보
+              Positioned(
+                left: cardWidth * 0.13,
+                top: cardHeight * 0.52,
+                child: SizedBox(
+                  width: cardWidth * 0.77,
+                  height: cardHeight * 0.23,
+                  child: Text(
+                    '기술 : $skill\n\n주요작품 : $works\n\n약력 : $bio',
+                    style: const TextStyle(
+                      color: Colors.black,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      height: 1.38,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/user/skill_list.dart
+++ b/lib/widgets/user/skill_list.dart
@@ -1,3 +1,4 @@
+import 'skill_detail.dart';
 import 'package:flutter/material.dart';
 
 class SkillList extends StatelessWidget {
@@ -10,7 +11,14 @@ class SkillList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: onTap,
+      onTap:
+          onTap ??
+          () {
+            showDialog(
+              context: context,
+              builder: (_) => SkillDetail(name: title, skill: '기술 예시', works: '주요작품 예시', bio: '약력 예시'),
+            );
+          },
       child: Container(
         height: 80,
         width: double.infinity,

--- a/lib/widgets/user/skill_list.dart
+++ b/lib/widgets/user/skill_list.dart
@@ -2,11 +2,10 @@ import 'package:flutter/material.dart';
 
 class SkillList extends StatelessWidget {
   final String title;
-  final String category;
   final String photoLabel;
   final VoidCallback? onTap;
 
-  const SkillList({super.key, this.title = '기술명', this.category = '카테고리', this.photoLabel = 'Photo', this.onTap});
+  const SkillList({super.key, this.title = '기술명', this.photoLabel = 'Photo', this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -38,20 +37,12 @@ class SkillList extends StatelessWidget {
             ),
             // 가운데 텍스트 영역
             Expanded(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    category,
-                    style: const TextStyle(fontSize: 10, fontWeight: FontWeight.bold, color: Colors.black38),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    title,
-                    style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold, color: Colors.black),
-                  ),
-                ],
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  title,
+                  style: const TextStyle(fontSize: 15, fontWeight: FontWeight.bold, color: Colors.black),
+                ),
               ),
             ),
             // 오른쪽 확장 아이콘


### PR DESCRIPTION
### 📌 PR 제목
> [Feat] 기술/장인 목록 구현

---

### ✅ 작업 개요
- 홈 화면에서 이동할 수 있는 기술 목록, 장인작가 목록 페이지 구현
- 기술 클릭 시 상세 정보 확인
- 장인작가 클릭 시 상세 정보 확인
- 매칭 신청 클릭 시 메세지 전송 가능
- 관련 이슈 번호: Closes #14 

---

### 🎨 주요 변경 사항
| 구분 | 내용 |
|------|------|
| UI 개발 | request_note, skill_detail, creator_detail 구현 |
| 기능 추가 | 새로운 페이지 2개에 목록들 구현, 각각의 목록 클릭 시 상세 정보 구현 |
| 기타 | 코드 리팩토링, 성능 최적화 등 |

---

### 📷 스크린샷 (변경 UI가 있다면 첨부)

---

### 📂 관련 파일 경로

---

### 🧪 테스트 및 검증
- [x] 기능 직접 테스트 완료  
- [x] 반응형 확인  
- [x] 오류 없음 확인

---

### 🙋 리뷰 포인트

---

### 📎 참고 자료

---

### 📌 기타 공유사항
